### PR TITLE
Remove margin for code blocks

### DIFF
--- a/assets/css/prism.css
+++ b/assets/css/prism.css
@@ -32,7 +32,6 @@ pre[class*="language-"] {
 /* Code blocks */
 pre[class*="language-"] {
 	padding: 1em;
-	margin: .5em 0;
 	overflow: auto;
 	border-radius: 0.3em;
 }


### PR DESCRIPTION
This was messing up the spacing around the code blocks when using Prism's syntax highlighting.